### PR TITLE
Improve hpc-codecov executable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,7 @@ jobs:
           steps:
             - run:
                 name: Convert coverage output
-                command: stack exec -- hpc-codecov hpc-codecov:hpc-codecov-test
+                command: stack exec hpc-codecov
             - codecov/upload:
                 file: coverage.json
 
@@ -158,7 +158,7 @@ jobs:
           name: Test minimal-example
           command: |
             stack test --coverage
-            stack exec -- hpc-codecov minimal-example:minimal-example-test -o actual.json
+            stack exec -- hpc-codecov -o actual.json
             diff -L actual actual.json -L expected coverage.json --unified
           working_directory: /root/src/minimal-example
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ executors:
     environment:
       STACK_YAML: << parameters.stack_yaml >>
       CI_LATEST: <<# parameters.latest >>1<</ parameters.latest >>
+      LANG: en_US.UTF-8
 
 orbs:
   codecov: codecov/codecov@1.0.2

--- a/README.md
+++ b/README.md
@@ -24,3 +24,23 @@ TODO
 I tried using [`codecov-haskell`](http://hackage.haskell.org/package/codecov-haskell),
 but I couldn't get it to build. I also wanted a tool that only did the conversion
 because I was using the really handy Codecov Circle CI orb.
+
+## FAQs
+
+### How do I convert coverage for an executable?
+
+1. Build the executable with coverage enabled (e.g. `stack build --coverage`)
+1. Run the executable
+1. This should generate a `.tix` file in the current directory
+1. (Optional) Merge the `.tix` file for the executable with the `.tix` file for
+   the test suites.
+
+   ```bash
+   # should list the .tix file for the executable and your test suites
+   $ find . -name '*.tix'
+
+   # merge with hpc
+   $ stack exec -- hpc combine my-exe.tix my-test-suite.tix --union > combined.tix
+   ```
+1. Run `stack exec -- hpc-codecov --file TIX_FILE`, with the path of the `.tix`
+   file

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Convert HPC output into JSON files that can be uploaded to [Codecov](https://cod
 ### Stack
 
 1. Run `stack build hpc-codecov`
-1. Run your test with coverage, e.g. `stack test my-project:my-test-suite --coverage`
-1. Run `stack exec -- hpc-codecov my-project:my-test-suite`
+1. Run your test(s) with coverage, e.g. `stack test --coverage`
+1. Run `stack exec hpc-codecov`
 1. Upload the JSON file with your desired method, e.g. using the
    [Codecov Bash uploader](https://docs.codecov.io/docs/about-the-codecov-bash-uploader)
 

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -15,7 +15,7 @@ import qualified Options.Applicative as Opt
 import Path (Abs, Dir, File, Path, Rel, reldir, (</>))
 import qualified Path
 import Path.IO (listDir, listDirRecur)
-import System.Process (readProcess)
+import System.Process (readProcessWithExitCode)
 import Trace.Hpc.Codecov (generateCodecovFromTix)
 import Trace.Hpc.Mix (Mix(..), readMix)
 import Trace.Hpc.Tix (Tix(..), TixModule, readTix, tixModuleName)
@@ -152,7 +152,9 @@ getPackages = do
     return (packageName, packageDir)
 
 readStack :: [String] -> IO String
-readStack args = head . lines <$> readProcess "stack" args ""
+readStack args = do
+  (_, stdout, _) <- readProcessWithExitCode "stack" args ""
+  return . head . lines $ stdout
 
 {- Utilities -}
 

--- a/exe/Main.hs
+++ b/exe/Main.hs
@@ -12,7 +12,7 @@ import qualified Options.Applicative as Opt
 import System.FilePath (takeDirectory, (<.>), (</>))
 import System.Process (readProcess)
 import Trace.Hpc.Codecov (generateCodecovFromTix)
-import Trace.Hpc.Mix (readMix)
+import Trace.Hpc.Mix (Mix(..), readMix)
 import Trace.Hpc.Tix (Tix(..), readTix, tixModuleName)
 
 data CLIOptions = CLIOptions
@@ -58,8 +58,8 @@ main = do
   mixDirectories <- getMixDirectories
 
   moduleToMixList <- forM tixModules $ \tixModule -> do
-    mixFile <- readMix mixDirectories (Right tixModule)
-    return (tixModuleName tixModule, mixFile)
+    Mix fileLoc _ _ _ mixEntries <- readMix mixDirectories (Right tixModule)
+    return (tixModuleName tixModule, (fileLoc, mixEntries))
 
   let moduleToMix = Map.toList . Map.fromListWith checkDupeMix $ moduleToMixList
       checkDupeMix mix1 mix2 = if mix1 == mix2

--- a/package.yaml
+++ b/package.yaml
@@ -47,7 +47,8 @@ executable:
     - bytestring >= 0.10.8.1 && < 0.11
     - hpc-codecov
     - optparse-applicative >= 0.13.2.0 && < 0.16
-    - path >= 0.5.13 && < 0.7
+    - path >= 0.6.0 && < 0.7
+    - path-io >= 1.2.2 && < 1.5
     - process >= 1.4.3.0 && < 1.7
     - unordered-containers >= 0.2.8.0 && < 0.3
     - yaml >= 0.8.24 && < 0.12

--- a/package.yaml
+++ b/package.yaml
@@ -62,4 +62,3 @@ tests:
       - tasty-discover
       - tasty-golden
       - tasty-hunit
-      - time

--- a/package.yaml
+++ b/package.yaml
@@ -45,9 +45,9 @@ executable:
   main: Main.hs
   dependencies:
     - bytestring >= 0.10.8.1 && < 0.11
-    - filepath >= 1.4.1.1 && < 1.5
     - hpc-codecov
     - optparse-applicative >= 0.13.2.0 && < 0.16
+    - path >= 0.5.13 && < 0.7
     - process >= 1.4.3.0 && < 1.7
     - unordered-containers >= 0.2.8.0 && < 0.3
     - yaml >= 0.8.24 && < 0.12

--- a/package.yaml
+++ b/package.yaml
@@ -45,7 +45,6 @@ executable:
   main: Main.hs
   dependencies:
     - bytestring >= 0.10.8.1 && < 0.11
-    - directory >= 1.3.0.0 && < 1.4
     - filepath >= 1.4.1.1 && < 1.5
     - hpc-codecov
     - optparse-applicative >= 0.13.2.0 && < 0.16

--- a/stack-ghc-8.0.yaml
+++ b/stack-ghc-8.0.yaml
@@ -2,3 +2,7 @@ resolver: lts-9.21
 
 packages:
   - .
+
+extra-deps:
+  - path-0.6.0
+  - path-io-1.3.0

--- a/test/Codecov.hs
+++ b/test/Codecov.hs
@@ -68,6 +68,23 @@ test_generate_codecov_resolve_hits = testCase "generateCodecovFromTix resolve hi
     , ("WithPartial.hs", [(1, Partial)])
     ]
 
+test_generate_codecov_merge_tixs :: TestTree
+test_generate_codecov_merge_tixs = testCase "generateCodecovFromTix merge .tix files" $
+  let report = generateCodecovFromTix
+        [ mkModuleToMix "Test" "Test.hs"
+            [ MixEntry (1, 1) (1, 10) (ExpBox True)
+            , MixEntry (2, 1) (2, 10) (ExpBox True)
+            , MixEntry (3, 1) (3, 10) (ExpBox True)
+            , MixEntry (4, 1) (4, 10) (ExpBox True)
+            ]
+        ]
+        [ mkTix "Test" [0, 0, 1, 1]
+        , mkTix "Test" [0, 1, 0, 1]
+        ]
+  in fromReport report @?=
+    [ ("Test.hs", [(1, Hit 0), (2, Hit 1), (3, Hit 1), (4, Hit 2)])
+    ]
+
 test_generate_codecov_non_expbox :: TestTree
 test_generate_codecov_non_expbox = testCase "generateCodecovFromTix non-ExpBox" $
   let report = generateCodecovFromTix

--- a/test/Codecov.hs
+++ b/test/Codecov.hs
@@ -11,7 +11,7 @@ import Data.Text (Text)
 import Test.Tasty (TestTree)
 import Test.Tasty.Golden (goldenVsString)
 import Test.Tasty.HUnit (testCase, (@?=))
-import Trace.Hpc.Mix (BoxLabel(..), CondBox(..), Mix(..))
+import Trace.Hpc.Mix (BoxLabel(..), CondBox(..))
 import Trace.Hpc.Tix (TixModule(..))
 import Trace.Hpc.Util (toHpcPos)
 

--- a/test/Codecov.hs
+++ b/test/Codecov.hs
@@ -8,7 +8,6 @@ import Data.Aeson (encode)
 import qualified Data.IntMap as IntMap
 import Data.List (sortOn)
 import Data.Text (Text)
-import Data.Time (UTCTime(..), fromGregorian)
 import Test.Tasty (TestTree)
 import Test.Tasty.Golden (goldenVsString)
 import Test.Tasty.HUnit (testCase, (@?=))
@@ -118,10 +117,9 @@ data MixEntry = MixEntry
   , mixEntryBoxLabel :: BoxLabel
   }
 
-mkModuleToMix :: String -> FilePath -> [MixEntry] -> (String, Mix)
-mkModuleToMix moduleName filePath mixEntries = (moduleName, Mix filePath updateTime 0 (length mixs) mixs)
+mkModuleToMix :: String -> FilePath -> [MixEntry] -> (String, FileInfo)
+mkModuleToMix moduleName filePath mixEntries = (moduleName, (filePath, mixs))
   where
-    updateTime = UTCTime (fromGregorian 1970 1 1) 0
     mixs = flip map mixEntries $ \MixEntry{..} ->
       let (startLine, startCol) = mixEntryStartPos
           (endLine, endCol) = mixEntryEndPos


### PR DESCRIPTION
* Support loading in all `.tix` files
* Support merging `.tix` data
* Test executable in CI
* Include executable coverage in CI coverage report